### PR TITLE
Fix: Unhandled promise reject

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@actions/core": "^1.2.3",
     "@actions/github": "^2.1.1",
-    "axios": "^0.19.2"
+    "axios": "^0.19.2",
+    "axios-retry": "^3.3.1"
   },
   "resolutions": {
     "axios/follow-redirects": "^1.12.1"

--- a/src/download-release-asset.js
+++ b/src/download-release-asset.js
@@ -5,6 +5,15 @@ const axios = require('axios').default;
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 const process = require('process');
+const axiosRetry = require('axios-retry');
+
+axiosRetry(
+  axios,
+  {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+  },
+);
 
 async function run() {
   try {

--- a/src/download-release-asset.js
+++ b/src/download-release-asset.js
@@ -82,7 +82,7 @@ async function run() {
     if (token != '') {
       headers.Authorization = 'token ' + token;
     }
-    for (let a of assets) {
+    await Promise.all(assets.map(a =>
       axios({
         method: 'get',
         url: a.url,
@@ -90,8 +90,8 @@ async function run() {
         responseType: 'stream',
       }).then(resp => {
         resp.data.pipe(fs.createWriteStream(`${path}/${a.name}`));
-      });
-    }
+      })
+    ));
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
   dependencies:
     tunnel "0.0.6"
 
+"@babel/runtime@^7.15.4":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@octokit/auth-token@^2.4.0":
   version "2.4.2"
   resolved "https://registry.npm.taobao.org/@octokit/auth-token/download/@octokit/auth-token-2.4.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40octokit%2Fauth-token%2Fdownload%2F%40octokit%2Fauth-token-2.4.2.tgz#10d0ae979b100fa6b72fa0e8e63e27e6d0dbff8a"
@@ -146,6 +153,14 @@ atob-lite@^2.0.0:
   resolved "https://registry.npm.taobao.org/atob-lite/download/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
   integrity sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
 
+axios-retry@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.3.1.tgz#47624646138aedefbad2ac32f226f4ee94b6dcab"
+  integrity sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
+
 axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.npm.taobao.org/axios/download/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
@@ -215,6 +230,11 @@ is-plain-object@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npm.taobao.org/is-plain-object/download/is-plain-object-3.0.1.tgz?cache=0&sync_timestamp=1593243670545&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-plain-object%2Fdownload%2Fis-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
   integrity sha1-Zi2S0kwKpDAkB7DUXSHyJRyF+Fs=
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -300,6 +320,11 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 semver@^5.5.0:
   version "5.7.1"


### PR DESCRIPTION
Fixes: https://github.com/i3h/download-release-asset/issues/7
I did not test these changes.

I split this into three commits
- Fix unhandled promise rejection
  - Collect all promises into an array and await them all using Promise.all and await.
- Use axios-retry to retry failing requests
- Update to node 16
  - See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

If merged or otherwise accepted, I would appreciate adding `hacktoberfest-accepted` label to this PR :)
See https://hacktoberfest.com/participation/#pr-mr-details for more info.